### PR TITLE
Use base `ifelse()` with matrices

### DIFF
--- a/R/draw_colors.R
+++ b/R/draw_colors.R
@@ -63,7 +63,7 @@ draw_colors_ribbon <- function(x){
 
 
 contrast_color <- function(x) {
-  args <- dplyr::if_else(grDevices::col2rgb(x) < 128, 255, 0) %>%
+  args <- ifelse(grDevices::col2rgb(x) < 128, 255, 0) %>%
     as.list() %>%
     append(255) %>%
     purrr::set_names(c("red", "green", "blue", "maxColorValue"))


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`if_else()` now uses vctrs, which generally makes it more permissive when there are varying types, but does require that the first input is a logical vector. You were using a logical matrix here, which is now an error. I think the easiest thing to do is to just switch you to using `ifelse()`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!